### PR TITLE
fix: update tauri config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,19 @@ Active development happens on the `dev` branch. The `main` branch is protected
 and only updated from `dev` when releasing. Feature branches should be created
 from `dev` and pull requests should target `dev`.
 
+## Developer Setup
+
+Install the Tauri CLI so you can run and build the desktop shell:
+
+```bash
+cargo install tauri-cli --locked
+```
+
+Then install the Node dependencies:
+
+```bash
+pnpm install
+```
+
+Use `pnpm dev` to start the React UI and `cargo tauri dev` to launch the Tauri
+application during development.

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -2,5 +2,10 @@
 name = "desktop"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
+tauri = { version = "2" }
+
+[build-dependencies]
+tauri-build = "2"

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build();
+}

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(all(not(debug_assertions), target_os = "windows"), windows_subsystem = "windows")]
+
 fn main() {
-    println!("Hello from desktop");
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,0 +1,17 @@
+{
+  "package": {
+    "productName": "AI-MD-Editor",
+    "version": "0.1.0"
+  },
+  "build": {
+    "beforeDevCommand": "",
+    "beforeBuildCommand": "",
+    "devPath": "../..",
+    "distDir": "../../packages/ui/dist"
+  },
+  "tauri": {
+    "bundle": {
+      "identifier": "com.aimd.editor"
+    }
+  }
+}

--- a/todo.md
+++ b/todo.md
@@ -46,11 +46,11 @@ _(check items as you complete them)_
 
 ## 3 Tauri / Rust Core
 
-- [ ] `cargo install tauri-cli`
-- [ ] `tauri init` in `apps/desktop`
-- [ ] Update `tauri.conf.json`
-  - [ ] `distDir` → `../../packages/ui/dist`
-  - [ ] Application name, identifier
+- [x] `cargo install tauri-cli`
+- [x] `tauri init` in `apps/desktop`
+- [x] Update `tauri.conf.json`
+  - [x] `distDir` → `../../packages/ui/dist`
+  - [x] Application name, identifier
 - [ ] Add Rust deps:
   - `rusqlite`, `serde`, `serde_json`, `uuid`, `zip-rs`, `walkdir`, `diffy`
 - [x] Set up Rust workspace (`Cargo.toml` at root)


### PR DESCRIPTION
## Summary
- update tauri distDir and bundle identifier
- bump tauri dependencies
- check off todo items for tauri config

## Testing
- `pnpm exec prettier --write .`
- `cargo fmt` *(fails: rustfmt not installed)*
- `pnpm exec eslint .` *(fails: Cannot find module '@eslint/js')*
- `pnpm -r test`
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `cargo test` *(fails: missing glib-2.0 package)*

------
https://chatgpt.com/codex/tasks/task_e_684c3d587d2883328146684bf17a99ad