### PR TITLE
Implement DB setup with mutex

### DIFF
--- a/apps/desktop/src/db.rs
+++ b/apps/desktop/src/db.rs
@@ -1,0 +1,42 @@
+use rusqlite::Connection;
+use std::{fs, sync::Mutex};
+use tauri::{AppHandle, Manager};
+
+const SCHEMA: &str = include_str!("../../../db/schema.sql");
+
+/// Initialize the SQLite database and run migrations.
+pub fn init_db(app: &AppHandle) -> tauri::Result<()> {
+    let resolver = app.path();
+    let mut path = resolver.app_data_dir()?;
+    fs::create_dir_all(&path)?;
+    path.push("editor.sqlite");
+
+    let conn = Connection::open(&path).map_err(|e| {
+        let err: Box<dyn std::error::Error> = e.into();
+        tauri::Error::Setup(err.into())
+    })?;
+    conn.execute_batch("PRAGMA foreign_keys = ON;")
+        .map_err(|e| {
+            let err: Box<dyn std::error::Error> = e.into();
+            tauri::Error::Setup(err.into())
+        })?;
+    let version: i64 = conn
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|e| {
+            let err: Box<dyn std::error::Error> = e.into();
+            tauri::Error::Setup(err.into())
+        })?;
+    if version == 0 {
+        conn.execute_batch(SCHEMA).map_err(|e| {
+            let err: Box<dyn std::error::Error> = e.into();
+            tauri::Error::Setup(err.into())
+        })?;
+        conn.pragma_update(None, "user_version", 1).map_err(|e| {
+            let err: Box<dyn std::error::Error> = e.into();
+            tauri::Error::Setup(err.into())
+        })?;
+    }
+
+    app.manage(Mutex::new(conn));
+    Ok(())
+}

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -1,7 +1,16 @@
-#![cfg_attr(all(not(debug_assertions), target_os = "windows"), windows_subsystem = "windows")]
+#![cfg_attr(
+    all(not(debug_assertions), target_os = "windows"),
+    windows_subsystem = "windows"
+)]
+
+mod db;
 
 fn main() {
     tauri::Builder::default()
+        .setup(|app| {
+            db::init_db(app.handle())?;
+            Ok(())
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/todo.md
+++ b/todo.md
@@ -61,9 +61,9 @@ _(check items as you complete them)_
 ## 4 SQLite Layer
 
 - [x] `db/schema.sql` — create `nodes`, `assets`, `op_log`
-- [ ] `db.rs`
-  - [ ] Open DB file in platform-specific app data dir
-  - [ ] Run migrations on startup
+- [x] `db.rs`
+  - [x] Open DB file in platform-specific app data dir
+  - [x] Run migrations on startup
 - [ ] CRUD helpers (`create_node`, `update_content`, `move_node`, `delete_node`)
 - [ ] Op-log insert on each mutating call
 - [ ] Unit tests: CRUD paths, cascade delete, retention trim


### PR DESCRIPTION
## Summary
- initialize SQLite database when the app starts
- wrap the `rusqlite` connection in a `Mutex`
- call `init_db` from Tauri setup

## Testing
- `pnpm exec prettier --write .`
- `pnpm exec eslint .`
- `pnpm -r test` *(no projects matched)*
- `cargo clippy --manifest-path apps/desktop/Cargo.toml -- -D warnings`
- `cargo test --manifest-path apps/desktop/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684d2c6f42648332b8b1b2dfef41421f